### PR TITLE
Fix: Update last-n on dominant speaker change

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1729,6 +1729,7 @@ public class Conference
             // likely want to notify the Endpoints participating in this
             // Conference.
             dominantSpeakerChanged();
+            speechActivityEndpointsChanged();
         }
         else if (ConferenceSpeechActivity.ENDPOINTS_PROPERTY_NAME.equals(
                 propertyName))


### PR DESCRIPTION
Clients were not receiving updates to the last-n endpoints when the
active speaker changed. Now, the LastNController for each
VideoChannel should be notified as active speaker updates and will
push out last-n change events on the channel, if necessary.