### PR TITLE
Refactor Conference/ConferenceSpeechActivity to break circular dependency and add unit tests

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1134,7 +1134,7 @@ public class Conference
                 content.setRecording(true, getRecordingPath());
             }
 
-            addContent(content);
+            contents.add(content);
         }
 
         if (logger.isInfoEnabled())
@@ -1155,24 +1155,28 @@ public class Conference
     }
 
     /**
-     * For testing only - adds a content to the list of <tt>Content</tt>s for
-     * this <tt>Conference</tt>
+     * For testing only - sets the <tt>List</tt> of <tt>Content</tt>s for this
+     * <tt>Conference</tt>
      *
-     * @param content
+     * @param contents the <tt>List</tt> of <tt>Content</tt>s to set for testing
      */
     @VisibleForTesting
-    void addContent(Content content) {
-        contents.add(content);
+    void setContents(List<Content> contents)
+    {
+        this.contents.clear();
+        this.contents.addAll(contents);
     }
 
     /**
      * For testing only - sets the <tt>List</tt> of <tt>Endpoint</tt>s for this
      * <tt>Conference</tt>
      *
-     * @param endpoints
+     * @param endpoints this <tt>List</tt> of <tt>Endpoint</tt>s to set for
+     * testing
      */
     @VisibleForTesting
-    void setEndpoints(List<Endpoint> endpoints) {
+    void setEndpoints(List<Endpoint> endpoints)
+    {
         this.endpoints.clear();
         this.endpoints.addAll(endpoints);
     }

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -17,7 +17,6 @@ package org.jitsi.videobridge;
 
 import java.beans.*;
 import java.io.*;
-import java.lang.ref.*;
 import java.lang.reflect.*;
 import java.text.*;
 import java.util.*;
@@ -28,6 +27,7 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.ColibriConferenceIQ.Recording.*;
 import net.java.sip.communicator.util.*;
 
+import com.google.common.annotations.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
@@ -425,7 +425,7 @@ public class Conference
      * in order to notify an <tt>Endpoint</tt> that the dominant speaker in this
      * multipoint conference has changed to <tt>dominantSpeaker</tt>
      */
-    private String createDominantSpeakerEndpointChangeEvent(
+    private static String createDominantSpeakerEndpointChangeEvent(
             Endpoint dominantSpeaker)
     {
         return
@@ -1128,11 +1128,13 @@ public class Conference
             }
 
             content = new Content(this, name);
+
             if (isRecording())
             {
                 content.setRecording(true, getRecordingPath());
             }
-            contents.add(content);
+
+            addContent(content);
         }
 
         if (logger.isInfoEnabled())
@@ -1150,6 +1152,29 @@ public class Conference
         }
 
         return content;
+    }
+
+    /**
+     * For testing only - adds a content to the list of <tt>Content</tt>s for
+     * this <tt>Conference</tt>
+     *
+     * @param content
+     */
+    @VisibleForTesting
+    void addContent(Content content) {
+        contents.add(content);
+    }
+
+    /**
+     * For testing only - sets the <tt>List</tt> of <tt>Endpoint</tt>s for this
+     * <tt>Conference</tt>
+     *
+     * @param endpoints
+     */
+    @VisibleForTesting
+    void setEndpoints(List<Endpoint> endpoints) {
+        this.endpoints.clear();
+        this.endpoints.addAll(endpoints);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -233,6 +233,7 @@ public class Conference
      * should be considered when generating statistics.
      */
     public Conference(Videobridge videobridge,
+                      ConferenceSpeechActivity speechActivity,
                       String id,
                       String focus,
                       String name,
@@ -244,6 +245,7 @@ public class Conference
             throw new NullPointerException("id");
 
         this.videobridge = videobridge;
+        this.speechActivity = speechActivity;
         this.id = id;
         this.focus = focus;
         this.eventAdmin = enableLogging ? videobridge.getEventAdmin() : null;
@@ -257,8 +259,8 @@ public class Conference
 
         lastKnownFocus = focus;
 
-        speechActivity = new ConferenceSpeechActivity(this);
         speechActivity.addPropertyChangeListener(propertyChangeListener);
+        addPropertyChangeListener(speechActivity.propertyChangeListener);
 
         if (enableLogging)
         {
@@ -692,6 +694,8 @@ public class Conference
                         throw (ThreadDeath) t;
                 }
             }
+
+            speechActivity.expire();
 
             // Close the transportManagers of this Conference. Normally, there
             // will be no TransportManager left to close at this point because

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -956,7 +956,7 @@ public class Conference
         }
 
         if (changed)
-            firePropertyChange(ENDPOINTS_PROPERTY_NAME, null, null);
+            fireEndpointsChangedEvent();
 
         return endpoint;
     }
@@ -1005,31 +1005,6 @@ public class Conference
      */
     public List<Endpoint> getEndpoints()
     {
-        List<Endpoint> endpoints;
-        boolean changed = false;
-
-        synchronized (this.endpoints)
-        {
-            endpoints = new ArrayList<>(this.endpoints.size());
-            for (Iterator<Endpoint> i = this.endpoints.iterator(); i.hasNext();)
-            {
-                Endpoint endpoint = i.next();
-
-                if (endpoint.isExpired())
-                {
-                    i.remove();
-                    changed = true;
-                }
-                else
-                {
-                    endpoints.add(endpoint);
-                }
-            }
-        }
-
-        if (changed)
-            firePropertyChange(ENDPOINTS_PROPERTY_NAME, null, null);
-
         return endpoints;
     }
 
@@ -1484,7 +1459,7 @@ public class Conference
         }
 
         if (removed)
-            firePropertyChange(ENDPOINTS_PROPERTY_NAME, null, null);
+            fireEndpointsChangedEvent();
 
         return removed;
     }
@@ -1769,6 +1744,17 @@ public class Conference
         {
             speechActivityEndpointsChanged();
         }
+    }
+
+    /**
+     * Fires a property change for the endpoints property and includes the
+     * the current <tt>List</tt> of <tt>Endpoint</tt>s wrapped in an
+     * unmodifiable <tt>List</tt> on the event as the new value.
+     */
+    private void fireEndpointsChangedEvent()
+    {
+        firePropertyChange(ENDPOINTS_PROPERTY_NAME, null,
+                Collections.unmodifiableList(endpoints));
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -310,7 +310,7 @@ public class ConferenceSpeechActivity
     }
 
     /**
-     * Returns a <tt>Endpoint</tt>, which has <tt>ssrc</tt> in its channel's
+     * Returns an <tt>Endpoint</tt>, which has <tt>ssrc</tt> in its channel's
      * list of received SSRCs, or <tt>null</tt> in case no such
      * <tt>Endpoint</tt> exists.
      *
@@ -319,7 +319,8 @@ public class ConferenceSpeechActivity
      * list of received SSRCs, or <tt>null</tt> in case no such
      * <tt>Endpoint</tt> exists.
      */
-    private Endpoint getEndpointByReceiveSSRC(long ssrc) {
+    private Endpoint getEndpointByReceiveSSRC(long ssrc)
+    {
         for (Endpoint endpoint : endpoints)
         {
             for (Channel channel : endpoint.getChannels(MediaType.AUDIO))
@@ -820,7 +821,8 @@ public class ConferenceSpeechActivity
      * @return <tt>true</tt> if there were any changes to the sorted list of
      * <tt>Endpoint</tt>s
      */
-    private boolean updateEndpoints() {
+    private boolean updateEndpoints()
+    {
         boolean updated = false;
 
         if (endpoints == null)

--- a/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -708,6 +708,7 @@ public class ConferenceSpeechActivity
      * interest, the name of the property and the old and new values of that
      * property
      */
+    @SuppressWarnings("unchecked")
     @Override
     public void propertyChange(PropertyChangeEvent ev)
     {
@@ -719,22 +720,16 @@ public class ConferenceSpeechActivity
 
         if (Conference.ENDPOINTS_PROPERTY_NAME.equals(propertyName))
         {
-            synchronized (syncRoot)
-            {
-                endpointsChanged = true;
-                maybeStartEventDispatcher();
-            }
-        }
-        else if (DominantSpeakerIdentification.DOMINANT_SPEAKER_PROPERTY_NAME
-                .equals(propertyName))
-        {
-            DominantSpeakerIdentification dominantSpeakerIdentification
-                = this.dominantSpeakerIdentification;
+            Object newValue = ev.getNewValue();
 
-            if ((dominantSpeakerIdentification != null)
-                    && dominantSpeakerIdentification.equals(ev.getSource()))
+            if (newValue instanceof List)
             {
-                // TODO Auto-generated method stub
+                synchronized (syncRoot)
+                {
+                    endpointsChanged = true;
+                    conferenceEndpoints = (List<Endpoint>) newValue;
+                    maybeStartEventDispatcher();
+                }
             }
         }
     }

--- a/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -119,23 +119,20 @@ public class ConferenceSpeechActivity
      * read and into which the <tt>Endpoint</tt> ID is to be written
      * @param ssrcKey the key in <tt>jsonObject</tt> with which the SSRC to be
      * resolved is associated
-     * @param conference
      * @param endpointKey the key in <tt>jsonObject</tt> with which the resolved
      * <tt>Endpoint</tt> ID is to be associated
      */
     @SuppressWarnings("unchecked")
-    private static void resolveSSRCAsEndpoint(
+    private void resolveSSRCAsEndpoint(
             JSONObject jsonObject,
             String ssrcKey,
-            Conference conference,
             String endpointKey)
     {
         long ssrc = parseSSRC(jsonObject.get(ssrcKey));
 
         if (ssrc != -1)
         {
-            Endpoint endpoint
-                = conference.findEndpointByReceiveSSRC(ssrc, MediaType.AUDIO);
+            Endpoint endpoint = getEndpointByReceiveSSRC(ssrc);
 
             if (endpoint != null)
             {
@@ -162,7 +159,7 @@ public class ConferenceSpeechActivity
 
     /**
      * The <tt>ActiveSpeakerDetector</tt> which detects/identifies the
-     * active/dominant speaker in {@link #conference}. 
+     * active/dominant speaker in {@link Conference}.
      */
     private ActiveSpeakerDetector activeSpeakerDetector;
 
@@ -173,17 +170,8 @@ public class ConferenceSpeechActivity
     private final Object activeSpeakerDetectorSyncRoot = new Object();
 
     /**
-     * The <tt>Conference</tt> for which this instance represents the speech
-     * activity of its <tt>Endpoint</tt>s. The reference will be set to
-     * <tt>null</tt> once the <tt>Conference</tt> gets expired.
-     * <tt>ConferenceSpeechActivity</tt> is a part of <tt>Conference</tt> and
-     * the operation of the former in the absence of the latter is useless.
-     */
-    private Conference conference;
-
-    /**
      * The <tt>Endpoint</tt> which is the dominant speaker in
-     * {@link #conference}.
+     * {@link Conference}.
      */
     private Endpoint dominantEndpoint;
 
@@ -202,14 +190,21 @@ public class ConferenceSpeechActivity
 
     /**
      * The ordered list of <tt>Endpoint</tt>s participating in
-     * {@link #conference} with the dominant (speaker) <tt>Endpoint</tt> at the
+     * {@link Conference} with the dominant (speaker) <tt>Endpoint</tt> at the
      * beginning of the list i.e. the dominant speaker history.
      */
     private List<Endpoint> endpoints;
 
     /**
+     * The unordered list of <tt>Endpoint</tt>s participating in
+     * {@link Conference}.
+     */
+    @SuppressWarnings("unchecked")
+    private List<Endpoint> conferenceEndpoints = Collections.EMPTY_LIST;
+
+    /**
      * The indicator which signals to {@link #eventDispatcher} that the
-     * <tt>endpoints</tt> set of {@link #conference} was changed and
+     * <tt>endpoints</tt> set of {@link Conference} was changed and
      * <tt>eventDispatcher</tt> may have to fire an event.
      */
     private boolean endpointsChanged = false;
@@ -231,13 +226,13 @@ public class ConferenceSpeechActivity
     /**
      * The <tt>PropertyChangeListener</tt> implementation employed by this
      * instance to listen to changes in the values of properties of interest to
-     * this instance. For example, listens to {@link #conference} in order to
+     * this instance. For example, listens to {@link Conference} in order to
      * notify about changes in the list of <tt>Endpoint</tt>s participating in
      * the multipoint conference. The implementation keeps a
      * <tt>WeakReference</tt> to this instance and automatically removes itself
      * from <tt>PropertyChangeNotifier</tt>s. 
      */
-    private final PropertyChangeListener propertyChangeListener
+    final PropertyChangeListener propertyChangeListener
         = new WeakReferencePropertyChangeListener(this);
 
     /**
@@ -247,23 +242,18 @@ public class ConferenceSpeechActivity
     private final Object syncRoot = new Object();
 
     /**
+     * The indicator for whether or not the <tt>Conference</tt> associated with
+     * this <tt>ConferenceSpeechActivity</tt> has expired and activity no longer
+     * needs to be monitored.
+     */
+    private boolean expired = false;
+
+    /**
      * Initializes a new <tt>ConferenceSpeechActivity</tt> instance which is to
      * represent the speech activity in a specific <tt>Conference</tt>.
-     *
-     * @param conference the <tt>Conference</tt> whose speech activity is to be
-     * represented by the new instance
      */
-    public ConferenceSpeechActivity(Conference conference)
+    public ConferenceSpeechActivity()
     {
-        Objects.requireNonNull(conference, "conference");
-
-        this.conference = conference;
-
-        /*
-         * The PropertyChangeListener will weakly reference this instance and
-         * will unregister itself from the conference sooner or later.
-         */
-        conference.addPropertyChangeListener(propertyChangeListener);
     }
 
     /**
@@ -276,20 +266,18 @@ public class ConferenceSpeechActivity
      */
     private void activeSpeakerChanged(long ssrc)
     {
-        Conference conference = getConference();
-
-        if (conference != null)
+        if (!expired)
         {
+            final Endpoint endpoint = getEndpointByReceiveSSRC(ssrc);
+
             if (logger.isTraceEnabled())
             {
                 logger.trace(
                         "The dominant speaker in conference "
-                            + conference.getID() + " is now the SSRC " + ssrc
-                            + ".");
+                            + endpoint.getConference().getID()
+                            + " is now the SSRC " + ssrc + ".");
             }
 
-            Endpoint endpoint
-                = conference.findEndpointByReceiveSSRC(ssrc, MediaType.AUDIO);
             boolean maybeStartEventDispatcher = false;
 
             synchronized (syncRoot)
@@ -322,6 +310,73 @@ public class ConferenceSpeechActivity
     }
 
     /**
+     * Returns a <tt>Endpoint</tt>, which has <tt>ssrc</tt> in its channel's
+     * list of received SSRCs, or <tt>null</tt> in case no such
+     * <tt>Endpoint</tt> exists.
+     *
+     * @param ssrc the SSRC to search for.
+     * @return an <tt>Endpoint</tt>, which has <tt>ssrc</tt> in its channel's
+     * list of received SSRCs, or <tt>null</tt> in case no such
+     * <tt>Endpoint</tt> exists.
+     */
+    private Endpoint getEndpointByReceiveSSRC(long ssrc) {
+        for (Endpoint endpoint : endpoints)
+        {
+            for (Channel channel : endpoint.getChannels(MediaType.AUDIO))
+            {
+                if (channel instanceof RtpChannel)
+                {
+                    RtpChannel rtpChannel = (RtpChannel) channel;
+                    if (rtpChannel.getStream().getRemoteSourceIDs()
+                        .contains(ssrc))
+                    {
+                        return endpoint;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Indicates that the <tt>Conference</tt> has expired so there is no need to
+     * listen for active speaker updates and clean up can take place.
+     */
+    public void expire() {
+        synchronized (syncRoot)
+        {
+            this.expired = true;
+
+            initializeEndpoints();
+        }
+
+        /*
+         * The Conference has expired so there is no point to listen to
+         * ActiveSpeakerDetector. Remove the activeSpeakerChangedListener
+         * for the purposes of completeness, not because it is strictly
+         * necessary.
+         */
+        ActiveSpeakerDetector activeSpeakerDetector =
+            this.activeSpeakerDetector;
+
+        if (activeSpeakerDetector != null)
+        {
+            activeSpeakerDetector.removeActiveSpeakerChangedListener(
+                activeSpeakerChangedListener);
+        }
+
+        DominantSpeakerIdentification dominantSpeakerIdentification =
+            this.dominantSpeakerIdentification;
+
+        if (dominantSpeakerIdentification != null)
+        {
+            dominantSpeakerIdentification
+                .removePropertyChangeListener(propertyChangeListener);
+        }
+    }
+
+    /**
      * Retrieves a JSON representation of
      * {@link #dominantSpeakerIdentification} for the purposes of the REST API
      * of Videobridge.
@@ -345,9 +400,7 @@ public class ConferenceSpeechActivity
         }
         else
         {
-            Conference conference = getConference();
-
-            if (conference == null)
+            if (expired)
             {
                 jsonObject = null;
             }
@@ -362,7 +415,6 @@ public class ConferenceSpeechActivity
                     resolveSSRCAsEndpoint(
                             jsonObject,
                             "dominantSpeaker",
-                            conference,
                             "dominantEndpoint");
 
                     // Resolve the ssrc of each one of the speakers of
@@ -378,7 +430,6 @@ public class ConferenceSpeechActivity
                                 resolveSSRCAsEndpoint(
                                         speaker,
                                         "ssrc",
-                                        conference,
                                         "endpoint");
                             }
                         }
@@ -391,7 +442,6 @@ public class ConferenceSpeechActivity
                                     resolveSSRCAsEndpoint(
                                             (JSONObject) speaker,
                                             "ssrc",
-                                            conference,
                                             "endpoint");
                                 }
                             }
@@ -472,9 +522,7 @@ public class ConferenceSpeechActivity
          */
         if (addActiveSpeakerChangedListener)
         {
-            Conference conference = getConference();
-
-            if (conference != null)
+            if (!expired)
             {
                 activeSpeakerDetector.addActiveSpeakerChangedListener(
                         activeSpeakerChangedListener);
@@ -491,49 +539,6 @@ public class ConferenceSpeechActivity
         }
 
         return activeSpeakerDetector;
-    }
-
-    /**
-     * Gets the <tt>Conference</tt> whose speech activity is represented by this
-     * instance.
-     *
-     * @return the <tt>Conference</tt> whose speech activity is represented by
-     * this instance or <tt>null</tt> if the <tt>Conference</tt> has expired.
-     */
-    private Conference getConference()
-    {
-        Conference conference = this.conference;
-
-        if ((conference != null) && conference.isExpired())
-        {
-            this.conference = conference = null;
-
-            /*
-             * The Conference has expired so there is no point to listen to
-             * ActiveSpeakerDetector. Remove the activeSpeakerChangedListener
-             * for the purposes of completeness, not because it is strictly
-             * necessary.
-             */
-            ActiveSpeakerDetector activeSpeakerDetector
-                = this.activeSpeakerDetector;
-
-            if (activeSpeakerDetector != null)
-            {
-                activeSpeakerDetector.removeActiveSpeakerChangedListener(
-                        activeSpeakerChangedListener);
-            }
-
-            DominantSpeakerIdentification dominantSpeakerIdentification
-                = this.dominantSpeakerIdentification;
-
-            if (dominantSpeakerIdentification != null)
-            {
-                dominantSpeakerIdentification.removePropertyChangeListener(
-                        propertyChangeListener);
-            }
-        }
-
-        return conference;
     }
 
     /**
@@ -601,36 +606,29 @@ public class ConferenceSpeechActivity
              * instance initialization. The list of Endpoints of this instance
              * is initially populated with the Endpoints of the conference. 
              */
-            if (endpoints == null)
-            {
-                Conference conference = getConference();
-
-                if (conference == null)
-                {
-                    endpoints = new ArrayList<>();
-                }
-                else
-                {
-                    List<Endpoint> conferenceEndpoints
-                        = conference.getEndpoints();
-
-                    endpoints = new ArrayList<>(conferenceEndpoints.size());
-                    for (Endpoint endpoint : conferenceEndpoints)
-                        endpoints.add(endpoint);
-                }
-            }
+            initializeEndpoints();
 
             // The return value is the list of Endpoints of this instance.
-            ret = new ArrayList<>(endpoints.size());
-            for (Iterator<Endpoint> i = endpoints.iterator(); i.hasNext();)
-            {
-                Endpoint endpoint = i.next();
-
-                if (endpoint != null)
-                    ret.add(endpoint);
-            }
+            ret = Collections.unmodifiableList(endpoints);
         }
+
         return ret;
+    }
+
+    /**
+     * Initialize the list of <tt>Endpoint</tt>s by populating it with the
+     * <tt>Endpoints</tt> of the <tt>Conference</tt> or an empty list if the
+     * Conference has expired.
+     */
+    private void initializeEndpoints() {
+        if (expired)
+        {
+            endpoints = new ArrayList<>();
+        }
+        else
+        {
+            endpoints = new ArrayList<>(conferenceEndpoints);
+        }
     }
 
     /**
@@ -713,22 +711,17 @@ public class ConferenceSpeechActivity
     public void propertyChange(PropertyChangeEvent ev)
     {
         // Cease to execute as soon as the Conference expires.
-        Conference conference = getConference();
-
-        if (conference == null)
+        if (expired)
             return;
 
         String propertyName = ev.getPropertyName();
 
         if (Conference.ENDPOINTS_PROPERTY_NAME.equals(propertyName))
         {
-            if (conference.equals(ev.getSource()))
+            synchronized (syncRoot)
             {
-                synchronized (syncRoot)
-                {
-                    endpointsChanged = true;
-                    maybeStartEventDispatcher();
-                }
+                endpointsChanged = true;
+                maybeStartEventDispatcher();
             }
         }
         else if (DominantSpeakerIdentification.DOMINANT_SPEAKER_PROPERTY_NAME
@@ -758,8 +751,8 @@ public class ConferenceSpeechActivity
      */
     private boolean runInEventDispatcher(EventDispatcher eventDispatcher)
     {
-        boolean endpointsChanged = false;
-        boolean dominantEndpointChanged = false;
+        boolean shouldFireEndpointsChangedEvent;
+        boolean shouldFireDominantEndpointChangedEvent = false;
 
         synchronized (syncRoot)
         {
@@ -774,9 +767,7 @@ public class ConferenceSpeechActivity
              * As soon as the Conference associated with this instance expires,
              * kill all background threads.
              */
-            Conference conference = getConference();
-
-            if (conference == null)
+            if (expired)
                 return false;
 
             long now = System.currentTimeMillis();
@@ -800,72 +791,7 @@ public class ConferenceSpeechActivity
             }
             eventDispatcherTime = now;
 
-            /*
-             * Synchronize the set of Endpoints of this instance with the set of
-             * Endpoints of the conference.
-             */
-            List<Endpoint> conferenceEndpoints = conference.getEndpoints();
-
-            if (endpoints == null)
-            {
-                endpoints = new ArrayList<>(conferenceEndpoints.size());
-                for (Endpoint endpoint : conferenceEndpoints)
-                {
-                    endpoints.add(endpoint);
-                }
-                endpointsChanged = true;
-            }
-            else
-            {
-                /*
-                 * Remove the Endpoints of this instance which are no longer in
-                 * the conference.
-                 */
-                for (Iterator<Endpoint> i = endpoints.iterator(); i.hasNext();)
-                {
-                    Endpoint endpoint = i.next();
-
-                    if (endpoint.isExpired())
-                    {
-                        i.remove();
-                        endpointsChanged = true;
-                    }
-                    else if (conferenceEndpoints.contains(endpoint))
-                    {
-                        conferenceEndpoints.remove(endpoint);
-                    }
-                    else
-                    {
-                        i.remove();
-                        endpointsChanged = true;
-                    }
-                }
-                /*
-                 * Add the Endpoints of the conference which are not in this
-                 * instance yet.
-                 */
-                if (!conferenceEndpoints.isEmpty())
-                {
-                    for (Endpoint endpoint : conferenceEndpoints)
-                    {
-                        endpoints.add(endpoint);
-                    }
-                    endpointsChanged = true;
-                }
-            }
-            this.endpointsChanged = false;
-
-            /*
-             * Make sure that the dominantEndpoint is at the top of the list of
-             * the Endpoints of this instance.
-             */
-            Endpoint dominantEndpoint = getDominantEndpoint();
-
-            if (dominantEndpoint != null)
-            {
-                endpoints.remove(dominantEndpoint);
-                endpoints.add(0, dominantEndpoint);
-            }
+            shouldFireEndpointsChangedEvent = updateEndpoints();
 
             /*
              * The activeSpeakerDetector decides when the dominantEndpoint
@@ -873,17 +799,91 @@ public class ConferenceSpeechActivity
              */
             if (this.dominantEndpointChanged)
             {
-                dominantEndpointChanged = true;
+                shouldFireDominantEndpointChangedEvent = true;
                 this.dominantEndpointChanged = false;
             }
         }
 
-        if (endpointsChanged)
+        if (shouldFireEndpointsChangedEvent)
             firePropertyChange(ENDPOINTS_PROPERTY_NAME, null, null);
-        if (dominantEndpointChanged)
+        if (shouldFireDominantEndpointChangedEvent)
             firePropertyChange(DOMINANT_ENDPOINT_PROPERTY_NAME, null, null);
 
         return true;
+    }
+
+    /**
+     * Synchronize the set of <tt>Endpoint</tt>s of this instance with the set
+     * of <tt>Endpoint</tt>s of the <tt>Conference</tt> and ensure the current
+     * dominant speaker is at the front.
+     *
+     * @return <tt>true</tt> if there were any changes to the sorted list of
+     * <tt>Endpoint</tt>s
+     */
+    private boolean updateEndpoints() {
+        boolean updated = false;
+
+        if (endpoints == null)
+        {
+            initializeEndpoints();
+            updated = true;
+        }
+        else
+        {
+            /*
+             * Remove the Endpoints of this instance which are no longer in
+             * the conference.
+             */
+            for (Iterator<Endpoint> i = endpoints.iterator(); i.hasNext();)
+            {
+                Endpoint endpoint = i.next();
+
+                if (endpoint.isExpired())
+                {
+                    i.remove();
+                    updated = true;
+                }
+                else if (conferenceEndpoints.contains(endpoint))
+                {
+                    conferenceEndpoints.remove(endpoint);
+                }
+                else
+                {
+                    i.remove();
+                    updated = true;
+                }
+            }
+
+            /*
+             * Add the Endpoints of the conference which are not in this
+             * instance yet.
+             */
+            if (!conferenceEndpoints.isEmpty())
+            {
+                for (Endpoint endpoint : conferenceEndpoints)
+                {
+                    endpoints.add(endpoint);
+                }
+
+                updated = true;
+            }
+        }
+
+        this.endpointsChanged = false;
+
+        /*
+         * Make sure that the dominantEndpoint is at the top of the list of
+         * the Endpoints of this instance.
+         */
+        Endpoint dominantEndpoint = getDominantEndpoint();
+
+        if (dominantEndpoint != null)
+        {
+            endpoints.remove(dominantEndpoint);
+            endpoints.add(0, dominantEndpoint);
+        }
+
+        return updated;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -272,6 +272,7 @@ public class Videobridge
                     conference
                         = new Conference(
                                 this,
+                                new ConferenceSpeechActivity(),
                                 id,
                                 focus,
                                 name,

--- a/src/test/java/org/jitsi/videobridge/ConferenceTest.java
+++ b/src/test/java/org/jitsi/videobridge/ConferenceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge;
+
+import java.beans.*;
+import java.util.*;
+
+import org.easymock.*;
+import org.jitsi.service.neomedia.*;
+import org.junit.*;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class ConferenceTest extends EasyMockSupport {
+    private Conference conference;
+    private Videobridge videobridgeMock;
+    private ConferenceSpeechActivity speechActivityMock;
+    private Content contentMock;
+    private RtpChannel channelMock;
+    private Endpoint endpointMock;
+    private List<Endpoint> endpoints;
+
+    @Before
+    public void setUp() {
+        videobridgeMock = mock(Videobridge.class);
+        speechActivityMock = niceMock(ConferenceSpeechActivity.class);
+        contentMock = mock(Content.class);
+        channelMock = mock(RtpChannel.class);
+        endpointMock = mock(Endpoint.class);
+
+        endpoints = new ArrayList<>();
+        endpoints.add(endpointMock);
+
+        conference = new Conference(videobridgeMock, speechActivityMock,
+            "fakeId", "focus", "name", false);
+
+        resetAll();
+    }
+
+    @Test
+    public void propertyChange_dominantSpeakerChange_broadcastUpdate()
+        throws Exception
+    {
+        final Capture<String> messageArgument = newCapture();
+
+        expectDominantSpeakerChanged(messageArgument);
+        expectSpeechActivityEndpointsChanged();
+
+        replayAll();
+
+        conference.addContent(contentMock);
+        conference.propertyChange(new PropertyChangeEvent(speechActivityMock,
+            ConferenceSpeechActivity.DOMINANT_ENDPOINT_PROPERTY_NAME, null,
+            null));
+
+        verifyAll();
+
+        assertTrue(messageArgument.getValue()
+            .contains("DominantSpeakerEndpointChangeEvent"));
+    }
+
+    @Test
+    public void propertyChange_endpointsChanged_broadcastUpdate() {
+        expectSpeechActivityEndpointsChanged();
+
+        replayAll();
+
+        conference.addContent(contentMock);
+        conference.propertyChange(new PropertyChangeEvent(speechActivityMock,
+            ConferenceSpeechActivity.ENDPOINTS_PROPERTY_NAME, null,
+            null));
+
+        verifyAll();
+    }
+
+    private void expectDominantSpeakerChanged(Capture<String> messageArgument)
+        throws Exception
+    {
+        expect(speechActivityMock.getDominantEndpoint())
+            .andReturn(endpointMock);
+
+        expect(endpointMock.isExpired()).andReturn(false);
+        endpointMock.sendMessageOnDataChannel(capture(messageArgument));
+
+        conference.setEndpoints(new LinkedList<>(Arrays.asList(endpointMock)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void expectSpeechActivityEndpointsChanged() {
+        List<Endpoint> endpoints = new ArrayList<>(Arrays.asList(endpointMock));
+
+        expect(speechActivityMock.getEndpoints())
+            .andReturn(endpoints);
+        expect(contentMock.getMediaType()).andReturn(MediaType.VIDEO);
+        expect(contentMock.getChannels())
+            .andReturn(new Channel[] { channelMock });
+        expect(channelMock.speechActivityEndpointsChanged(endpoints))
+            .andReturn(endpoints);
+        contentMock.askForKeyframes((List<Endpoint>) anyObject());
+    }
+}

--- a/src/test/java/org/jitsi/videobridge/ConferenceTest.java
+++ b/src/test/java/org/jitsi/videobridge/ConferenceTest.java
@@ -116,7 +116,6 @@ public class ConferenceTest
         expect(speechActivityMock.getDominantEndpoint())
             .andReturn(endpointMock);
 
-        expect(endpointMock.isExpired()).andReturn(false);
         endpointMock.sendMessageOnDataChannel(capture(messageArgument));
 
         conference.setEndpoints(new LinkedList<>(Arrays.asList(endpointMock)));

--- a/src/test/java/org/jitsi/videobridge/ConferenceTest.java
+++ b/src/test/java/org/jitsi/videobridge/ConferenceTest.java
@@ -25,32 +25,50 @@ import org.junit.*;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
-public class ConferenceTest extends EasyMockSupport {
+/**
+ * Tests the Conference class at the unit level
+ */
+public class ConferenceTest
+    extends EasyMockSupport
+{
     private Conference conference;
+
     private Videobridge videobridgeMock;
+
     private ConferenceSpeechActivity speechActivityMock;
+
     private Content contentMock;
+
     private RtpChannel channelMock;
+
     private Endpoint endpointMock;
+
     private List<Endpoint> endpoints;
 
     @Before
-    public void setUp() {
+    public void setUp()
+    {
         videobridgeMock = mock(Videobridge.class);
         speechActivityMock = niceMock(ConferenceSpeechActivity.class);
         contentMock = mock(Content.class);
         channelMock = mock(RtpChannel.class);
         endpointMock = mock(Endpoint.class);
 
-        endpoints = new ArrayList<>();
-        endpoints.add(endpointMock);
+        endpoints = new ArrayList<>(Arrays.asList(endpointMock));
 
-        conference = new Conference(videobridgeMock, speechActivityMock,
-            "fakeId", "focus", "name", false);
+        conference =
+            new Conference(videobridgeMock, speechActivityMock, "fakeId",
+                "focus", "name", false);
 
         resetAll();
     }
 
+    /**
+     * Tests the <tt>propertyChange</tt> method of <tt>Conference</tt> when an
+     * event signaling that the dominant speaker has changed is received.
+     *
+     * @throws Exception
+     */
     @Test
     public void propertyChange_dominantSpeakerChange_broadcastUpdate()
         throws Exception
@@ -62,7 +80,7 @@ public class ConferenceTest extends EasyMockSupport {
 
         replayAll();
 
-        conference.addContent(contentMock);
+        conference.setContents(new ArrayList<>(Arrays.asList(contentMock)));
         conference.propertyChange(new PropertyChangeEvent(speechActivityMock,
             ConferenceSpeechActivity.DOMINANT_ENDPOINT_PROPERTY_NAME, null,
             null));
@@ -73,16 +91,21 @@ public class ConferenceTest extends EasyMockSupport {
             .contains("DominantSpeakerEndpointChangeEvent"));
     }
 
+    /**
+     * Tests the <tt>propertyChange</tt> method of <tt>Conference</tt> when an
+     * event signaling that the participating endpoints have changed is
+     * received.
+     */
     @Test
-    public void propertyChange_endpointsChanged_broadcastUpdate() {
+    public void propertyChange_endpointsChanged_broadcastUpdate()
+    {
         expectSpeechActivityEndpointsChanged();
 
         replayAll();
 
-        conference.addContent(contentMock);
+        conference.setContents(new ArrayList<>(Arrays.asList(contentMock)));
         conference.propertyChange(new PropertyChangeEvent(speechActivityMock,
-            ConferenceSpeechActivity.ENDPOINTS_PROPERTY_NAME, null,
-            null));
+            ConferenceSpeechActivity.ENDPOINTS_PROPERTY_NAME, null, null));
 
         verifyAll();
     }
@@ -100,11 +123,9 @@ public class ConferenceTest extends EasyMockSupport {
     }
 
     @SuppressWarnings("unchecked")
-    private void expectSpeechActivityEndpointsChanged() {
-        List<Endpoint> endpoints = new ArrayList<>(Arrays.asList(endpointMock));
-
-        expect(speechActivityMock.getEndpoints())
-            .andReturn(endpoints);
+    private void expectSpeechActivityEndpointsChanged()
+    {
+        expect(speechActivityMock.getEndpoints()).andReturn(endpoints);
         expect(contentMock.getMediaType()).andReturn(MediaType.VIDEO);
         expect(contentMock.getChannels())
             .andReturn(new Channel[] { channelMock });

--- a/src/test/java/org/jitsi/videobridge/VideoBridgeTestSuite.java
+++ b/src/test/java/org/jitsi/videobridge/VideoBridgeTestSuite.java
@@ -26,6 +26,7 @@ import org.junit.runners.*;
 @RunWith(Suite.class)
 @Suite.SuiteClasses(
     {
+        ConferenceTest.class,
         FocusControlTest.class,
         RawUdpConferenceTest.class,
         BridgeShutdownTest.class // This one must be the last one


### PR DESCRIPTION
The Conference class is no longer passed as an argument to ConferenceSpeechActivity's constructor. ConferenceSpeechActivity receives updates from Conference via event handlers that were already in place, but were not passing values.

ConferenceSpeechActivity no longer frequently checks the validity of the Conference as Conference will explicitly notify it when the conference has expired and clean up can take place.

Unit tests verify dominant speaker and endpoint changed events are broadcast to the channel.