### PR TITLE
fix: Request keyframes from last-n endpoints for newly joined channels

### DIFF
--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -589,11 +589,14 @@ public class VideoChannel
             if (lastNController.getLastN() >= 0 ||
                     lastNController.getCurrentLastN() >= 0)
             {
+                final List<String> forwardedEndpoints =
+                        lastNController.getForwardedEndpoints();
                 lastNController.initializeConferenceEndpoints();
                 sendLastNEndpointsChangeEventOnDataChannel(
-                        lastNController.getForwardedEndpoints(),
+                        forwardedEndpoints,
                         null,
                         null);
+                getContent().askForKeyframesById(forwardedEndpoints);
             }
 
             updateInLastN(this);


### PR DESCRIPTION
As users join a meeting with last-n enabled they need to request
keyframes from the currently forwarded endpoints in order to
begin receiving video.