### PR TITLE
Added datachannel patch

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -212,7 +212,7 @@ public class Endpoint
      * Whether or not the bridge should be the peer which opens the data channel
      * (as opposed to letting the far peer/client open it).
      */
-    private static final boolean OPEN_DATA_LOCALLY = false;
+    private static final boolean OPEN_DATA_LOCALLY = true;
 
     /**
      * The executor which runs bandwidth probing.


### PR DESCRIPTION
"change open dc locally config" - open data-channel from video-bridge rather than the client since jitsi uses colibri websockets and we still use the webrtc data channel.